### PR TITLE
Add tags to the list of saved params

### DIFF
--- a/lib/zendesk2/client/models/ticket.rb
+++ b/lib/zendesk2/client/models/ticket.rb
@@ -1,7 +1,7 @@
 class Zendesk2::Client::Ticket < Zendesk2::Model
   extend Zendesk2::Attributes
 
-  PARAMS = %w[external_id via requester_id submitter_id assignee_id organization_id subject description fields recipient status collaborator_ids]
+  PARAMS = %w[external_id via requester_id submitter_id assignee_id organization_id subject description fields recipient status collaborator_ids tags]
 
   identity :id,                type: :id
   attribute :external_id


### PR DESCRIPTION
We need to add and remove tags in Zendesk, to automatically manage views.

Adding this allows the tags to be edited & saved for a ticket.
