### PR TITLE
Add support for token-based login to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Default credentials will be read in from `~/.zendesk2` file in YAML format.
 :subdomain: zendeskdev
 :username: zendeskedge@example.com
 :password: wickedsecurepassword
+:token: reallylongrandomstringprovidedbyzendesk
 ```
 
 ### Creating the client
 
-Either the absolute url or the subdomain is required.  Username and password is always required.
+Either the absolute url or the subdomain is required. Username and either password or token are always required.
 
 ```ruby
 Zendesk2::Client.new(subdomain: "engineyard", username: "orchestra", password: "gwoo")
@@ -42,8 +43,8 @@ Zendesk2::Client.new(subdomain: "engineyard", username: "orchestra", password: "
 or
 
 ```ruby
-Zendesk2::Client.new(url: "http://support.cloud.engineyard.com", username: "mate", password: "bambilla")
-=> #<Zendesk2::Client::Real:0x007fd1bae486b0 @url="http://support.cloud.engineyard.com", @username="mate", @password="bambilla", …>
+Zendesk2::Client.new(url: "http://support.cloud.engineyard.com", username: "mate", token: "asdfghjkl1qwertyuiop5zxcvbnm3")
+=> #<Zendesk2::Client::Real:0x007fd1bae486b0 @url="http://support.cloud.engineyard.com", @username="mate", @token="asdfghjkl1qwertyuiop5zxcvbnm3", …>
 ```
 
 ### Resources

--- a/lib/zendesk2/client.rb
+++ b/lib/zendesk2/client.rb
@@ -108,14 +108,17 @@ class Zendesk2::Client < Cistern::Service
       adapter            = options[:adapter] || :net_http
       connection_options = options[:connection_options] || {ssl: {verify: false}}
       @username          = options[:username] || Zendesk2.defaults[:username]
+      token              = options[:token] || Zendesk2.defaults[:token]
       password           = options[:password] || Zendesk2.defaults[:password]
-      @token             = options[:token]
+      @username         += "/token" if token
+      @auth_token        = token || password
 
-      raise "Missing required options: [:username, :password]" unless @username && password
+      raise "Missing required options: :username" unless @username 
+      raise "Missing required options: :password or :token" unless password || token
 
       @connection = Faraday.new({url: @url}.merge(connection_options)) do |builder|
         # response
-        builder.use Faraday::Request::BasicAuthentication, @username, password
+        builder.use Faraday::Request::BasicAuthentication, @username, @auth_token
         builder.use Faraday::Response::RaiseError
         builder.response :json
 


### PR DESCRIPTION
This adds support for logging in using an API token in addition to a password. If both token and password are specified in configuration, token is given preference.
