### PR TITLE
Implementation of user.jwt_login_url, the currently recommended way to SSO into zendesk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
+#To avoid warnings from JWT
+gem 'json', '~> 1.7.7'
 
 group :test do
   gem 'guard-rspec'

--- a/lib/zendesk2.rb
+++ b/lib/zendesk2.rb
@@ -5,7 +5,7 @@ require 'addressable/uri'
 require 'cistern'
 require 'faraday'
 require 'faraday_middleware'
-
+require 'jwt'
 # stdlib
 require 'forwardable'
 require 'logger'

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe "client" do
+
+  it "can be configured" do
+    client = Zendesk2::Client.new(:url => "https://myzen.zendesk.com",
+                                  :username => "person@place.com",
+                                  :password => "wickedsecure",
+                                  :token => "12345678901234567890",
+                                  :jwt_token => "234823472398472938423234")
+    client.url.should eq "https://myzen.zendesk.com"
+    client.username.should eq "person@place.com"
+    client.token.should eq "12345678901234567890"
+    client.jwt_token.should eq "234823472398472938423234"
+  end
+
+end

--- a/spec/users_spec.rb
+++ b/spec/users_spec.rb
@@ -120,10 +120,25 @@ describe "users" do
       user.reload.email.should == original_email
     end
 
-    it "should form login url" do
+    it "should form 'legacy' login url" do
       return_to = "http://engineyard.com"
-      uri = Addressable::URI.parse(user.login_url(Time.now.to_s, return_to: return_to))
+      uri = Addressable::URI.parse(user.login_url(Time.now.to_s, return_to: return_to, token: "in-case-you-dont-have-it-in ~/.zendesk2 (aka ci)"))
       uri.query_values["return_to"].should == return_to
+      uri.query_values["name"].should eq user.name
+      uri.query_values["email"].should eq user.email
+      uri.query_values["hash"].should_not be_nil
     end
+
+    it "should form jwt login url" do
+      return_to = "http://engineyard.com"
+      uri = Addressable::URI.parse(user.jwt_login_url(return_to: return_to, jwt_token: "in-case-you-dont-have-it-in ~/.zendesk2 (aka ci)"))
+      uri.query_values["return_to"].should == return_to
+      uri.query_values["name"].should be_nil
+      uri.query_values["email"].should be_nil
+      uri.query_values["jwt"].should_not be_nil
+
+      #TODO: try JWT.decode
+    end
+
   end
 end

--- a/zendesk2.gemspec
+++ b/zendesk2.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency "faraday"
   gem.add_dependency "faraday_middleware"
   gem.add_dependency "addressable"
+  gem.add_dependency "jwt"
 end


### PR DESCRIPTION
also: fix bug in saving 'token' from config (added test only reproduces bug in non-mocked)
