### PR TITLE
Grab comments with the ticket comments endpoint, rather than through audits

### DIFF
--- a/lib/zendesk2/client.rb
+++ b/lib/zendesk2/client.rb
@@ -12,6 +12,7 @@ class Zendesk2::Client < Cistern::Service
   collection :organizations
   collection :ticket_audits
   collection :tickets
+  collection :ticket_comments
   collection :topic_comments
   collection :topics
   collection :users
@@ -70,6 +71,7 @@ class Zendesk2::Client < Cistern::Service
   request :get_ticket
   request :get_ticket_audit
   request :get_ticket_audits
+  request :get_ticket_comments
   request :get_tickets
   request :get_topic
   request :get_topic_comment
@@ -165,16 +167,17 @@ class Zendesk2::Client < Cistern::Service
 
     def self.data
       @data ||= {
-        :categories     => {},
-        :forums         => {},
-        :groups         => {},
-        :identities     => {},
-        :organizations  => {},
-        :ticket_audits  => {},
-        :tickets        => {},
-        :topic_comments => {},
-        :topics         => {},
-        :users          => {},
+        :categories      => {},
+        :forums          => {},
+        :groups          => {},
+        :identities      => {},
+        :organizations   => {},
+        :ticket_audits   => {},
+        :ticket_comments => {},
+        :tickets         => {},
+        :topic_comments  => {},
+        :topics          => {},
+        :users           => {},
       }
     end
 

--- a/lib/zendesk2/client/models/ticket.rb
+++ b/lib/zendesk2/client/models/ticket.rb
@@ -115,9 +115,9 @@ class Zendesk2::Client::Ticket < Zendesk2::Model
     self.connection.ticket_audits(ticket_id: self.identity).all
   end
 
-  # @return [Array<Zendesk2::Client::AuditEvent>] audit events of type 'Comment'
+  # @return [Array<Zendesk2::Client::TicketComment>] all comments for this ticket
   def comments
-    audits.map{|audit| audit.events.select{|e| e.type == "Comment"}}.flatten
+    self.connection.ticket_comments(ticket_id: self.identity).all
   end
 
   private

--- a/lib/zendesk2/client/models/ticket_comments.rb
+++ b/lib/zendesk2/client/models/ticket_comments.rb
@@ -1,0 +1,23 @@
+class Zendesk2::Client::TicketComments < Zendesk2::Collection
+
+  model Zendesk2::Client::TicketComment
+
+  attribute :ticket_id, type: :integer
+
+  self.collection_method = :get_ticket_comments
+  self.collection_root   = "comments"
+
+  def ticket
+    self.connection.tickets.get(self.ticket_id)
+  end
+
+  def all(params={})
+    requires :ticket_id
+
+    body = connection.send(collection_method, {"ticket_id" => self.ticket_id}.merge(params)).body
+
+    collection = self.clone.load(body[collection_root])
+    collection.merge_attributes(Cistern::Hash.slice(body, "count", "next_page", "previous_page"))
+    collection
+  end
+end

--- a/lib/zendesk2/client/requests/get_ticket_comments.rb
+++ b/lib/zendesk2/client/requests/get_ticket_comments.rb
@@ -1,0 +1,22 @@
+class Zendesk2::Client
+  class Real
+    def get_ticket_comments(params={})
+      ticket_id = params["ticket_id"]
+      request(
+        :method => :get,
+        :path => "/tickets/#{ticket_id}/comments.json"
+      )
+    end
+  end # Real
+
+  class Mock
+    def get_ticket_comments(params={})
+      ticket_id = params["ticket_id"]
+
+      page(params,
+           :ticket_comments,
+           "/tickets/#{ticket_id}/comments.json",
+           "comments")
+    end
+  end # Mock
+end

--- a/lib/zendesk2/client/requests/update_ticket.rb
+++ b/lib/zendesk2/client/requests/update_ticket.rb
@@ -18,6 +18,18 @@ class Zendesk2::Client
       body      = self.data[:tickets][ticket_id].merge!(params)
 
       if comment = params["comment"]
+        comment_id = self.class.new_id
+        comment_data = self.data[:ticket_comments][comment_id] = {
+            "id"          => comment_id,
+            "type"        => "Comment",
+            "author_id"   => current_user["id"],
+            "body"        => comment["body"],
+            "html_body"   => "<p>#{comment["body"]}</p>",
+            "public"      => comment["public"].nil? ? true : comment["public"],
+            "trusted"     => comment["trusted"].nil? ? true : comment["trusted"],
+            "attachments" => comment["attachments"] || [],
+        }
+
         audit_id = self.class.new_id
         self.data[:ticket_audits][audit_id] = {
           "id"         => audit_id,
@@ -42,16 +54,7 @@ class Zendesk2::Client
             },
             "custom" => {},
           },
-          "events" => [
-            "id"          => self.class.new_id,
-            "type"        => "Comment",
-            "author_id"   => current_user["id"],
-            "body"        => comment["body"],
-            "html_body"   => "<p>#{comment["body"]}</p>",
-            "public"      => comment["public"].nil? ? true : comment["public"],
-            "trusted"     => comment["trusted"].nil? ? true : comment["trusted"],
-            "attachments" => comment["attachments"] || [],
-          ]
+          "events" => [comment_data]
         }
       end
 


### PR DESCRIPTION
Grabbing comments through audits was causing a stack level too deep error for me.
This uses the documented ticket comments endpoint (http://developer.zendesk.com/documentation/rest_api/ticket_comments.html) to grab the comments, rather than going through audits.
