### PR TITLE
corrected URI reference so it uses the standard lib

### DIFF
--- a/lib/zendesk2.rb
+++ b/lib/zendesk2.rb
@@ -12,6 +12,7 @@ require 'forwardable'
 require 'logger'
 require 'time'
 require 'yaml'
+require 'uri'
 
 module Zendesk2
   require 'zendesk2/attributes'

--- a/lib/zendesk2/client.rb
+++ b/lib/zendesk2/client.rb
@@ -156,7 +156,7 @@ class Zendesk2::Client < Cistern::Service
     def initialize(options={})
       options[:subdomain] ||= "mock"
       url = zendesk_url(options)
-      @url  = URI.parse(url).to_s
+      @url  = ::URI.parse(url).to_s
 
       @logger            = options[:logger] || Logger.new(nil)
       adapter            = options[:adapter] || :net_http
@@ -246,7 +246,7 @@ class Zendesk2::Client < Cistern::Service
       url = zendesk_url(options)
 
       @url  = url
-      @path = URI.parse(url).path
+      @path = ::URI.parse(url).path
       @username, @password = options[:username], options[:password]
       @token = options[:token]
       @jwt_token = options[:jwt_token]


### PR DESCRIPTION
First off, thanks for writing this rubygem, it's the best one out there in my opinion... The others just simply suck, but that's partially due to the enormous size of Zendesk's API.

Some context:
- Using Ruby 2.1.1 via RVM
- Mac OS X 10.9.4
- Using ~/.zendesk2 (btw- thank you for this lovely design. It is wonderful)

``` irb
2.1.1 :001 > require 'zendesk2'
 => true
2.1.1 :002 > client = Zendesk2::Client.new
NameError: uninitialized constant Zendesk2::Client::Real::URI
    from /Users/jbarnett/.rvm/gems/ruby-2.1.1/gems/zendesk2-0.5.3/lib/zendesk2/client.rb:159:in `initialize'
    from /Users/jbarnett/.rvm/gems/ruby-2.1.1/gems/cistern-0.9.1/lib/cistern/service.rb:181:in `new'
    from /Users/jbarnett/.rvm/gems/ruby-2.1.1/gems/cistern-0.9.1/lib/cistern/service.rb:181:in `new'
    from (irb):2
    from /Users/jbarnett/.rvm/rubies/ruby-2.1.1/bin/irb:11:in `<main>'
```

I fixed this issue with these code changes.
