### PR TITLE
Zendesk2::Client::Real created incorrectly with mock.zendesk.com instead of using defined subdomain in ~/.zendesk2

### DIFF
--- a/lib/zendesk2/client.rb
+++ b/lib/zendesk2/client.rb
@@ -154,7 +154,6 @@ class Zendesk2::Client < Cistern::Service
     attr_accessor :username, :url, :token, :logger, :jwt_token
 
     def initialize(options={})
-      options[:subdomain] ||= "mock"
       url = zendesk_url(options)
       @url  = URI.parse(url).to_s
 


### PR DESCRIPTION
This line isn't necessary because of #zendesk_url + #form_zendesk_url and it only creates problems. I don't have a wider context, so this may be wrong. In my immediate testing this seemed to resolve my issue.
