### PR TITLE
Add optional locale parameter to get_help_center_sections_articles

### DIFF
--- a/lib/zendesk2/client/requests/get_help_center_sections_articles.rb
+++ b/lib/zendesk2/client/requests/get_help_center_sections_articles.rb
@@ -1,6 +1,10 @@
 class Zendesk2::Client::GetHelpCenterSectionsArticles < Zendesk2::Client::Request
   request_path { |r|
-    "/help_center/sections/#{r.section_id}/articles.json"
+    if locale = r.params["locale"]
+      "/help_center/#{locale}/sections/#{r.section_id}/articles.json"
+    else
+      "/help_center/sections/#{r.section_id}/articles.json"
+    end
   }
 
   page_params!


### PR DESCRIPTION
We recently added a new locale besides en-us, and now when querying `/help_center/sections/{section_id}/articles.json` zendesk replies back with a 302 redirecting to `/help_center/sections/en-us/{section_id}/articles.json`.

This is just a bandage to add a locale option to the `get_help_center_sections_articles` request. Ideally, redirects would be handled in some way.