### PR TITLE
remove 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 cache:
   - bundler
 rvm:
-  - "2.2"
-  - "1.9"
+  - 2.3
+  - 2.2
+  - 2.1
 script: "bundle exec rake --trace"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 cache:
   - bundler
 rvm:
-  - 2.3
-  - 2.2
-  - 2.1
+  - 2.3.0
+  - 2.2.4
+  - 2.1.8
 script: "bundle exec rake --trace"
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,4 @@ rvm:
   - "1.9"
 script: "bundle exec rake --trace"
 notifications:
-  email:
-    on_success: never
-    on_failure: change
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ end
 
 group :test do
   gem 'awesome_print'
-  gem 'guard-bundler', require: false
-  gem 'guard-rspec', '~> 4.3', require: false
   gem 'rspec', '~> 3.2'
   gem 'rack-test'
 end

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/lanej/zendesk2)
 [![Dependency Status](https://gemnasium.com/lanej/zendesk2.png)](https://gemnasium.com/lanej/zendesk2)
 
-Ruby client for the [Zendesk V2 API](http://developer.zendesk.com/documentation/rest_api/introduction.html) using [cistern](https://github.com/lanej/cistern) and [faraday](https://github.com/technoweenie/faraday)
+Ruby client for the [Zendesk V2 API](http://developer.zendesk.com/documentation/rest_api/introduction.html) using [cistern](https://github.com/lanej/cistern) and [faraday](https://github.com/technoweenie/faraday).  Ruby > 2.0 is required
 
 ## Installation
 

--- a/lib/zendesk2/client/model.rb
+++ b/lib/zendesk2/client/model.rb
@@ -30,7 +30,11 @@ class Zendesk2::Client::Model
 
   # re-define Cistern::Attributes#missing_attributes to require non-blank
   def missing_attributes(args)
-    ([:service] | args).select{|arg| val = send("#{arg}"); val.nil? || val == "" }
+    missing, required = super(args)
+    blank, still_required = required.partition { |_,v| "" == v }
+    missing.merge!(Hash[blank])
+
+    [missing, Hash[still_required]]
   end
 
   def update!(attributes)

--- a/zendesk2.gemspec
+++ b/zendesk2.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Zendesk2::VERSION
 
+  gem.required_ruby_version = '~> 2.0'
+
   gem.add_dependency "cistern",            "~> 2.2"
   gem.add_dependency "faraday",            "~> 0.9"
   gem.add_dependency "faraday_middleware", "~> 0.9"

--- a/zendesk2.gemspec
+++ b/zendesk2.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '~> 2.0'
 
-  gem.add_dependency "cistern",            "~> 2.2"
+  gem.add_dependency "cistern",            "~> 2.3"
   gem.add_dependency "faraday",            "~> 0.9"
   gem.add_dependency "faraday_middleware", "~> 0.9"
   gem.add_dependency "jwt",                "~> 1.0"


### PR DESCRIPTION
* Ruby 1.9 is [no longer supported](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/)