### PR TITLE
Add locale option to categories endpoint

### DIFF
--- a/lib/zendesk2/help_center/get_help_center_categories.rb
+++ b/lib/zendesk2/help_center/get_help_center_categories.rb
@@ -2,7 +2,10 @@
 class Zendesk2::GetHelpCenterCategories
   include Zendesk2::Request
 
-  request_path { |_| '/help_center/categories.json' }
+  request_path do |r|
+    locale = r.params['locale']
+    locale ? "/help_center/#{locale}/categories.json" : "/help_center/categories.json"
+  end
 
   page_params!
 

--- a/spec/help_center/categories_spec.rb
+++ b/spec/help_center/categories_spec.rb
@@ -5,7 +5,7 @@ describe 'help_center/categories' do
   let(:client) { create_client }
 
   include_examples 'zendesk#resource',
-                   collection: -> { client.help_center_categories },
+                   collection: -> { client.help_center_categories(locale: 'en-us') },
                    create_params: -> { { name: mock_uuid, locale: 'en-us' } },
                    update_params: -> { { name: mock_uuid } },
                    search: false


### PR DESCRIPTION
Zendesk Help Center API providing [endpoint](https://developer.zendesk.com/rest_api/docs/help_center/categories) to get categories.

This PR adding support to pass `locale` option when provided in order to get the category with desired locale.
