### PR TITLE
feature(*): create tickets with collaborator descriptions

### DIFF
--- a/lib/zendesk2/ticket.rb
+++ b/lib/zendesk2/ticket.rb
@@ -115,17 +115,6 @@ class Zendesk2::Ticket
     )
   end
 
-  # @return [Array<Zendesk2::User>] All users CCD on this ticket
-  def collaborators
-    collaborator_ids.map { |cid| cistern.users.get(cid) }
-  end
-
-  # Update list of users to be CCD on this ticket
-  # @param [Array<Zendesk2::User>] collaborators list of users
-  def collaborators=(collaborators)
-    self.collaborator_ids = collaborators.map(&:identity)
-  end
-
   # @return [Zendesk2::TicketAudits] all audits for this ticket
   def audits
     cistern.ticket_audits(ticket_id: identity).all
@@ -139,5 +128,25 @@ class Zendesk2::Ticket
   # @return [Array<Zendesk2::TicketComment>] all comments for this ticket
   def comments
     cistern.ticket_comments(ticket_id: identity).all
+  end
+
+  # @return [Array<Zendesk2::User>] All users CCD on this ticket
+  def collaborators
+    (collaborator_ids || []).map { |id| cistern.users.get(id) }
+  end
+
+  def collaborators=(collaborators)
+    collaborators = [collaborators] unless collaborators.is_a?(Array)
+
+    value = collaborators.map do |collaborator|
+      case collaborator
+      when Zendesk2::User
+        collaborator.identity
+      else
+        collaborator
+      end
+    end
+
+    attributes[:collaborators] = value
   end
 end

--- a/spec/tickets_spec.rb
+++ b/spec/tickets_spec.rb
@@ -39,6 +39,25 @@ describe 'Zendesk2' do
       end
     end
 
+    it 'should create collaborators' do
+      name = 'Josh Lane'
+      email = mock_email
+      collaborating_user = client.users.create!(email: mock_email, name: mock_uuid)
+      collaborating_user_id = client.users.create!(email: mock_email, name: mock_uuid).identity
+
+      ticket = client.tickets.create!(
+        subject: mock_uuid,
+        description: mock_uuid,
+        collaborators: [{ name: name, email: email }, collaborating_user_id, collaborating_user],
+      )
+
+      collaborators = [collaborating_user]
+      collaborators << client.users.get(collaborating_user_id)
+      collaborators << client.users.search(email: email).first if Zendesk2.mocking?
+
+      expect(ticket.collaborators).to include(*collaborators)
+    end
+
     context 'valid requester exists' do
       it 'sets organization id' do
         ticket = client.tickets.create!(subject: mock_uuid, description: mock_uuid, requester_id: 11_111_111_111_199)


### PR DESCRIPTION
```ruby
zendesk.tickets.create!(collaborators: 33)
zendesk.tickets.create!(collaborators: [33])
zendesk.tickets.create!(collaborators: {name: 'josh lane', email: 'jlane@example.com'})
zendesk.tickets.create!(collaborators: zendesk.users.get(33))
zendesk.tickets.create!(collaborators: [33, {name: 'josh lane', email: 'jlane@example.com}, zendesk.users.get(33)])
```

* https://developer.zendesk.com/rest_api/docs/core/tickets#setting-collaborators