### PR TITLE
Actually destroy the help center article in mocks

### DIFF
--- a/lib/zendesk2/help_center/destroy_help_center_article.rb
+++ b/lib/zendesk2/help_center/destroy_help_center_article.rb
@@ -10,6 +10,8 @@ class Zendesk2::DestroyHelpCenterArticle
   end
 
   def mock
-    mock_response('article' => find!(:help_center_articles, article_id))
+    delete!(:help_center_articles, article_id)
+
+    mock_response(nil)
   end
 end


### PR DESCRIPTION
Currently doesn't destroy the help center article in mocks.