### PR TITLE
fix(request): handle missing requester information in #create_ticket

### DIFF
--- a/lib/zendesk2/create_ticket.rb
+++ b/lib/zendesk2/create_ticket.rb
@@ -98,12 +98,15 @@ class Zendesk2::CreateTicket
       else
         raise ArgumentError, "Unprocessable collaborator: #{spec}"
       end
-    end
+    end.compact
 
     create_params.merge!('collaborator_ids' => ids)
   end
 
   def find_or_create_user(user)
+    return nil unless user['email']
+    user['name'] ||= user['email'].split("@").first.capitalize
+
     known_user = cistern.users.search(email: user['email']).first
 
     user_id = (known_user && known_user.identity) ||

--- a/spec/tickets_spec.rb
+++ b/spec/tickets_spec.rb
@@ -58,6 +58,28 @@ describe 'Zendesk2' do
       expect(ticket.collaborators).to include(*collaborators)
     end
 
+    it 'fails to create collaborators with missing collaborators[email]' do
+      ticket = client.tickets.create!(
+        subject: mock_uuid,
+        description: mock_uuid,
+        collaborators: { name: 'josh', email: nil },
+      )
+
+      expect(ticket.collaborators).to be_empty
+    end
+
+    it 'fails to create collaborators with missing collaborators[name]' do
+      email = mock_email
+
+      ticket = client.tickets.create!(
+        subject: mock_uuid,
+        description: mock_uuid,
+        collaborators: { name: nil, email: email },
+      )
+
+      expect(ticket.collaborators.map(&:email)).to contain_exactly(email)
+    end
+
     context 'valid requester exists' do
       it 'sets organization id' do
         ticket = client.tickets.create!(subject: mock_uuid, description: mock_uuid, requester_id: 11_111_111_111_199)


### PR DESCRIPTION
name, email descriptions of requester do not work without email
information.  without name information, the name is inferred from the
email