### PR TITLE
Add ticket_id scope for Ticket Audits

### DIFF
--- a/lib/zendesk2/ticket_audits.rb
+++ b/lib/zendesk2/ticket_audits.rb
@@ -13,6 +13,8 @@ class Zendesk2::TicketAudits
   self.model_method      = :get_ticket_audit
   self.model_root        = 'audit'
 
+  scopes << :ticket_id
+
   def ticket
     cistern.tickets.get(ticket_id)
   end


### PR DESCRIPTION
Pagination is broken for `TicketAudits`. Add the `ticket_id` scope so this
is preserved when paginating.

Because there is no create endpoint for `TicketAudits`, perhaps we should alter the `zendesk#resource` shared example to accept and arbitrary block for creation when you pass `create: false` as an option?
