### PR TITLE
fix master: rubocop and deprecated cistern calls

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.2
   DisplayCopNames: true
 Metrics/LineLength:
   Max: 120

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'rubocop', '~> 0.42', require: false
+gem 'rubocop', '~> 0.44.1', require: false
 
 group :test do
   gem 'pry-nav'

--- a/lib/zendesk2.rb
+++ b/lib/zendesk2.rb
@@ -19,7 +19,7 @@ require 'securerandom'
 module Zendesk2
   include Cistern::Client.with(interface: :module)
 
-  USER_AGENT = <<-UA
+  USER_AGENT = <<-UA.freeze
   Ruby/#{RUBY_VERSION} (#{RUBY_PLATFORM}; #{RUBY_ENGINE}) Zendesk2/#{Zendesk2::VERSION} Faraday/#{Faraday::VERSION}
   UA
 

--- a/lib/zendesk2/create_ticket.rb
+++ b/lib/zendesk2/create_ticket.rb
@@ -105,7 +105,7 @@ class Zendesk2::CreateTicket
 
   def find_or_create_user(user)
     return nil unless user['email']
-    user['name'] ||= user['email'].split("@").first.capitalize
+    user['name'] ||= user['email'].split('@').first.capitalize
 
     known_user = cistern.users.search(email: user['email']).first
 

--- a/lib/zendesk2/help_center/search_help_center_articles.rb
+++ b/lib/zendesk2/help_center/search_help_center_articles.rb
@@ -6,16 +6,9 @@ class Zendesk2::SearchHelpCenterArticles
 
   attr_reader :query
 
-  def _mock(query, params = {})
+  def call(query, params)
     @query = query
-    setup(params)
-    mock
-  end
-
-  def _real(query, params = {})
-    @query = query
-    setup(params)
-    real
+    super(params)
   end
 
   def mock

--- a/lib/zendesk2/mock.rb
+++ b/lib/zendesk2/mock.rb
@@ -3,6 +3,7 @@ class Zendesk2::Mock
   attr_reader :username, :url, :token, :jwt_token
   attr_accessor :last_request
 
+  # rubocop:disable Metrics/BlockLength
   def self.data
     @data ||= Hash.new do |h, k|
       h[k] = {

--- a/lib/zendesk2/organizations.rb
+++ b/lib/zendesk2/organizations.rb
@@ -15,11 +15,12 @@ class Zendesk2::Organizations
   def find_by_external_id(external_id)
     body = cistern.get_organization_by_external_id('external_id' => external_id).body
     data = body.delete('organizations')
-    if data
-      collection = clone.load(data)
-      collection.merge_attributes(Cistern::Hash.slice(body, 'count', 'next_page', 'previous_page'))
-      collection
-    end
+
+    return unless data
+
+    collection = clone.load(data)
+    collection.merge_attributes(Cistern::Hash.slice(body, 'count', 'next_page', 'previous_page'))
+    collection
   end
 
   self.collection_method = :get_organizations

--- a/lib/zendesk2/paged_collection.rb
+++ b/lib/zendesk2/paged_collection.rb
@@ -58,19 +58,19 @@ module Zendesk2::PagedCollection
   end
 
   def next_page
-    if next_page_link
-      options = { 'url' => next_page_link }
-      options['filtered'] = filtered if respond_to?(:filtered) # searchable
-      new_page.all(options)
-    end
+    return nil unless next_page_link
+
+    options = { 'url' => next_page_link }
+    options['filtered'] = filtered if respond_to?(:filtered) # searchable
+    new_page.all(options)
   end
 
   def previous_page
-    if previous_page_link
-      options = { 'url' => previous_page_link }
-      options['filtered'] = filtered if respond_to?(:filtered) # searchable
-      new_page.all(options)
-    end
+    return nil unless previous_page_link
+
+    options = { 'url' => previous_page_link }
+    options['filtered'] = filtered if respond_to?(:filtered) # searchable
+    new_page.all(options)
   end
 
   # Attempt creation of resource and explode if unsuccessful

--- a/lib/zendesk2/request.rb
+++ b/lib/zendesk2/request.rb
@@ -52,18 +52,11 @@ module Zendesk2::Request
 
   attr_reader :params
 
-  def setup(params)
+  def call(*args)
+    params = args.last.is_a?(Hash) ? args.pop : {}
     @params = Cistern::Hash.stringify_keys(params)
-  end
 
-  def _mock(params = {})
-    setup(params)
-    mock
-  end
-
-  def _real(params = {})
-    setup(params)
-    real
+    dispatch
   end
 
   def page_params!(options)

--- a/lib/zendesk2/search.rb
+++ b/lib/zendesk2/search.rb
@@ -10,16 +10,9 @@ class Zendesk2::Search
 
   attr_reader :query
 
-  def _mock(query, params = {})
+  def call(query, params)
     @query = query
-    setup(params)
-    mock
-  end
-
-  def _real(query, params = {})
-    @query = query
-    setup(params)
-    real
+    super(params)
   end
 
   def mock

--- a/lib/zendesk2/search_organization.rb
+++ b/lib/zendesk2/search_organization.rb
@@ -10,7 +10,7 @@ class Zendesk2::SearchOrganization
 
   page_params!
 
-  def call(query, params={})
+  def call(query, params = {})
     @query = query
     super(params)
   end

--- a/lib/zendesk2/search_organization.rb
+++ b/lib/zendesk2/search_organization.rb
@@ -10,16 +10,9 @@ class Zendesk2::SearchOrganization
 
   page_params!
 
-  def _mock(query, params = {})
+  def call(query, params={})
     @query = query
-    setup(params)
-    mock
-  end
-
-  def _real(query, params = {})
-    @query = query
-    setup(params)
-    real
+    super(params)
   end
 
   def mock

--- a/lib/zendesk2/search_user.rb
+++ b/lib/zendesk2/search_user.rb
@@ -10,16 +10,9 @@ class Zendesk2::SearchUser
 
   page_params!
 
-  def _mock(query, params = {})
+  def call(query, params)
     @query = query
-    setup(params)
-    mock
-  end
-
-  def _real(query, params = {})
-    @query = query
-    setup(params)
-    real
+    super(params)
   end
 
   def mock

--- a/lib/zendesk2/searchable.rb
+++ b/lib/zendesk2/searchable.rb
@@ -21,15 +21,15 @@ module Zendesk2::Searchable
   # @see http://developer.zendesk.com/documentation/rest_api/search.html
   def search(terms, params = {})
     query = (terms.is_a?(Hash) ? search_by_hash(terms) : search_by_string(terms))
-
     body = cistern.send(self.class.search_request, query, params).body
     data = body.delete('results')
 
-    if data
-      load(data)
-      merge_attributes(Cistern::Hash.slice(body, 'count', 'next_page', 'previous_page').merge('filtered' => true))
-      self
-    end
+    return nil unless data
+
+    load(data)
+
+    merge_attributes(Cistern::Hash.slice(body, 'count', 'next_page', 'previous_page').merge('filtered' => true))
+    self
   end
 
   private

--- a/lib/zendesk2/version.rb
+++ b/lib/zendesk2/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Zendesk2
-  VERSION = '1.11.0'
+  VERSION = '1.11.0'.freeze
 end

--- a/spec/shared/zendesk_resource.rb
+++ b/spec/shared/zendesk_resource.rb
@@ -59,7 +59,7 @@ shared_examples 'zendesk#resource' do |options = {}|
     context 'index' do
       let!(:resource) { @resource = collection.create!(instance_exec(&options[:create_params])) }
 
-      after { @resource.destroy if @resource }
+      after { @resource&.destroy }
 
       # real index actions sometimes have delays in population
       it 'lists', mock_only: true do

--- a/spec/shared/zendesk_resource.rb
+++ b/spec/shared/zendesk_resource.rb
@@ -59,7 +59,7 @@ shared_examples 'zendesk#resource' do |options = {}|
     context 'index' do
       let!(:resource) { @resource = collection.create!(instance_exec(&options[:create_params])) }
 
-      after { @resource&.destroy }
+      after { @resource.destroy if @resource }
 
       # real index actions sometimes have delays in population
       it 'lists', mock_only: true do


### PR DESCRIPTION
* set correct rubocop `TargetRubyVersion` to `2.2`
* remove usage of deprecated cistern functions (remove `_mock` and `_real`)