### PR TITLE
Allow newer versions of jwt to be used

### DIFF
--- a/zendesk2.gemspec
+++ b/zendesk2.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cistern',            '~> 2.3'
   gem.add_dependency 'faraday',            '~> 0.9'
   gem.add_dependency 'faraday_middleware', '~> 0.9'
-  gem.add_dependency 'jwt',                '~> 2.0'
+  gem.add_dependency 'jwt',                '>= 1.0', '< 3.0'
   gem.add_dependency 'json',               '> 1.7', '< 3.0'
 end

--- a/zendesk2.gemspec
+++ b/zendesk2.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'cistern',            '~> 2.3'
   gem.add_dependency 'faraday',            '~> 0.9'
   gem.add_dependency 'faraday_middleware', '~> 0.9'
-  gem.add_dependency 'jwt',                '~> 1.0'
+  gem.add_dependency 'jwt',                '~> 2.0'
   gem.add_dependency 'json',               '> 1.7', '< 3.0'
 end


### PR DESCRIPTION
This is to allow apps that depend on this gem to update to newer versions of the JWT gem.

Tested in integration with the app i am working on and existing functionality (articles/tickets/options) still work after updating the jwt gem to 2.2.1